### PR TITLE
making edit forms non-isomorphic

### DIFF
--- a/lib/jsx_forms.jsx
+++ b/lib/jsx_forms.jsx
@@ -19,6 +19,10 @@ var PathNameComponent = React.createClass({
     this.setState({slug: event.target.checked});
   },
 
+  leafChange: function(event) {
+    this.setState({leaf: event.target.value});
+  },
+
   render: function() {
     var path = this.props.path;
     if (path instanceof SitePath) {
@@ -26,19 +30,19 @@ var PathNameComponent = React.createClass({
     }
     return (<fieldset>
       <div className="pure-u-1-3">
-      <input className="pure-input-1" name="root" type="text" value={path} id="root"
+      <input className="pure-input-1" name="root" type="text" value={path}
         readOnly disabled />
       </div>
       <div className="pure-u-1-3">
       <input className="pure-input-1" type="text"
-        defaultValue={this.state.leaf} disabled={this.state.slug} 
-        name="leaf" id="leaf"
+        value={this.state.leaf} disabled={this.state.slug} 
+        name="leaf" onChange={this.leafChange}
         placeholder={this.getIntlMessage("PATH")} />
       </div>
       <div className="pure-u-1-3">
       <label htmlFor="autogenSlug" className="pure-checkbox">
         <input type="checkbox" onChange={this.slugSwitch} 
-         defaultChecked={this.state.slug} name="autogenSlug" id="slug" />
+         checked={this.state.slug} name="autogenSlug" />
         <FormattedMessage message={this.getIntlMessage('AUTO_GENERATE_SLUG')} />
       </label>
       </div>

--- a/lib/protoset.js
+++ b/lib/protoset.js
@@ -275,18 +275,18 @@ function BaseBehaviorMixin(page) {
       title: req.entity.summary.title,
       abstract: req.entity.summary.abstract,
       block: req.entity.data.posting
-    }
+    };
     res.expose(editData, 'formData');
     next();
-  })
+  });
 
   page.viewRouter.routeAll('create.html', function(req, res, next) {
     var editData = {
       path: req.sitepath.toDottedPath(),
-    }
+    };
     res.expose(editData, 'formData');
     next();
-  })
+  });
 
   page.viewRouter.routeAll('edit.html', basicView.bind(this, 'edit', 'edit', null));
   page.viewRouter.routeAll('create.html', basicView.bind(this, 'create', 'create', null));

--- a/lib/protoset.js
+++ b/lib/protoset.js
@@ -269,6 +269,25 @@ function BaseBehaviorMixin(page) {
     });
   });
 
+  page.viewRouter.routeAll('edit.html', function(req, res, next) {
+    var editData = {
+      path: req.sitepath.toDottedPath(),
+      title: req.entity.summary.title,
+      abstract: req.entity.summary.abstract,
+      block: req.entity.data.posting
+    }
+    res.expose(editData, 'formData');
+    next();
+  })
+
+  page.viewRouter.routeAll('create.html', function(req, res, next) {
+    var editData = {
+      path: req.sitepath.toDottedPath(),
+    }
+    res.expose(editData, 'formData');
+    next();
+  })
+
   page.viewRouter.routeAll('edit.html', basicView.bind(this, 'edit', 'edit', null));
   page.viewRouter.routeAll('create.html', basicView.bind(this, 'create', 'create', null));
   page.viewRouter.routeAll('tag.html', basicView.bind(this, 'tag', 'tag', null));

--- a/scheme/default/bundles/page.js
+++ b/scheme/default/bundles/page.js
@@ -6,41 +6,12 @@ if (!global.Intl) {
 var React = require('react');
 var PageFormComponent = require('../partials/page.jsx');
 
-var numblocks = document.getElementById('numblocks');
-var block;
+var block = formData.block;
 
-function fetchBlock(prefix) {
-  var format = document.getElementById(prefix + "[format]").value;
-  if (format === 'pragma') {
-    var query = document.getElementById(prefix + "[query]").value;
-    return {query: query, format: format};
-  } else if (format === 'html') {
-    var source = document.getElementById(prefix + "[source]").innerHTML;
-    return {htmltext: source, format: format};
-  } else {
-    var source = document.getElementById(prefix + "[source]").innerHTML;
-    return {source: source, format: format};
-  }
-}
+var root = formData.path;
 
-if (numblocks) {
-  var blocks = [];
-  for(var i = 0; i < numblocks.value; ++i) {
-    var prefix = 'posting[blocks][' + i + ']'
-    blocks.push(fetchBlock(prefix));
-  }
-  block = {format: 'section', blocks: blocks};
-} else {
-  block = fetchBlock('posting');
-}
-
-var root, slug;
-if (section !== 'edit') {
-  root = document.getElementById('root').value;
-  slug = document.getElementById('slug').value;
-}
-var title = document.getElementById('title').innerHTML;
-var abstract = document.getElementById('abstract').innerHTML;
+var title = formData.title;
+var abstract = formData.abstract;
 
 var renderTarget = document.getElementById('pageform');
 var PathFactory = React.createFactory(PageFormComponent);

--- a/scheme/default/create.html
+++ b/scheme/default/create.html
@@ -2,7 +2,8 @@
 {<view-content}
 <div class="pure-u-4-5">
 
-<div id="pageform">{@react component="page.jsx" locales=intl.locales messages=intl.messages section=section path=path title=summary.title abstract=summary.abstract block=data.posting proto=meta.proto errors=errors noCache="true" /}</div>
+<div id="pageform"></div>
+
 </div>
 <script src="/resources/bundles/page.js"></script>
 

--- a/scheme/default/partials/page.jsx
+++ b/scheme/default/partials/page.jsx
@@ -1,4 +1,4 @@
-var React = require('react');
+var React = require('react/addons');
 var ReactIntl = require('react-intl');
 var IntlMixin  = ReactIntl.IntlMixin;
 var FormattedMessage  = ReactIntl.FormattedMessage;
@@ -8,14 +8,18 @@ var SingleError = JsxForms.SingleError;
 var ErrorsList = JsxForms.ErrorsList;
 
 var PageFormComponent = React.createClass({
-  mixins: [IntlMixin],
+  mixins: [IntlMixin, React.addons.LinkedStateMixin],
 
   getInitialState: function() {
+    var state = {};
     if (this.props.errors) {
-      return {errors: this.props.errors};
+      state.errors = this.props.errors;
     } else {
-      return {errors: {}};
+      state.errors = {};
     }
+    state.title = this.props.title;
+    state.abstract = this.props.abstract;
+    return state;
   },
 
   render: function() {
@@ -34,14 +38,15 @@ var PageFormComponent = React.createClass({
     return (
       <form id="draft" action={action} id="userform-form" method="post" className="pure-form pure-form-stacked" onSubmit={this.onSubmit}>
       <fieldset><h1>
-       <textarea rows="1" className="pure-input-1" placeholder={this.getIntlMessage("TITLE")}
-        defaultValue={this.props.title} name="title" id="title" /></h1>
+       <textarea rows="1" className="pure-input-1" 
+        placeholder={this.getIntlMessage("TITLE")} name="title" 
+        valueLink={this.linkState('title')} /></h1>
       <ErrorsList errors={this.state.errors.title} />
       </fieldset>
       <fieldset>
-      <textarea rows="5" className="pure-input-1" id="abstract" name="abstract" 
+      <textarea rows="5" className="pure-input-1" name="abstract" 
         placeholder={this.getIntlMessage("ABSTRACT")}
-        defaultValue={this.props.abstract}>
+        valueLink={this.linkState('abstract')} >
       </textarea>
       <ErrorsList errors={this.state.errors.abstract} />
       </fieldset>

--- a/tests/casper/test-crud-base.js
+++ b/tests/casper/test-crud-base.js
@@ -92,6 +92,8 @@ describe('Base type CRUD', function() {
          'posting[source]': 'post data here do stuff etc'}, true);
     });
 
+    casper.wait(100);
+
     casper.then(function() {
       expect(casper.currentHTTPStatus).to.equal(200);
       'div.footer'.should.be.inDOM.and.be.visible;

--- a/tests/unit/test-jsx_forms.js
+++ b/tests/unit/test-jsx_forms.js
@@ -26,7 +26,7 @@ describe('PathNameComponent', function() {
     leafInput.props.disabled.should.equal(true);
 
     var checkInput = form.props.children[2].props.children;
-    checkInput.props.children[0].props.defaultChecked.should.equal(true);
+    checkInput.props.children[0].props.checked.should.equal(true);
   });
 
   it('should render with leaf set', function() {
@@ -47,10 +47,10 @@ describe('PathNameComponent', function() {
     var leafInput = form.props.children[1].props.children;
     leafInput.type.should.equal('input');
     leafInput.props.disabled.should.equal(false);
-    leafInput.props.defaultValue.should.equal('chocolate');
+    leafInput.props.value.should.equal('chocolate');
 
     var checkInput = form.props.children[2].props.children;
-    checkInput.props.children[0].props.defaultChecked.should.equal(false);
+    checkInput.props.children[0].props.checked.should.equal(false);
   });
 
   it('should render with SitePath instead of string', function() {
@@ -72,7 +72,7 @@ describe('PathNameComponent', function() {
     leafInput.props.disabled.should.equal(true);
 
     var checkInput = form.props.children[2].props.children;
-    checkInput.props.children[0].props.defaultChecked.should.equal(true);
+    checkInput.props.children[0].props.checked.should.equal(true);
   });
 });
 


### PR DESCRIPTION
The edit forms are only isomorphic so that you can edit pages with JavaScript
disabled (or a really old version of the browser).  Given the code complexity,
it seemed to be too much trouble to keep things this way, so now they are
entirely client-side generated.