### PR TITLE
allowing the resource page to move, removing .env messages.

### DIFF
--- a/lib/conf.js
+++ b/lib/conf.js
@@ -1,13 +1,20 @@
+var path = require('path');
 var pg = require('pg').native;
-require('dotenv').load();
+require('dotenv').load({silent: true});
 
 var Conf = function() {
   this._data = {};
   this._data.endpoints = {};
   this._data.endpoints.postgres = process.env.RM3_PG || 'postgresql://wirehead:rm3test@127.0.0.1/rm3test';
+  this._data.path = {};
+  this._data.path.resources = process.env.RM3_RESOURCES || path.join(__dirname, '../scheme/default/static')
   this._data.certificates = {};
   this._data.certificates.twitterConsumerKey = process.env.RM3_TWITTER_CONSUMER_KEY;
   this._data.certificates.twitterConsumerSecret = process.env.RM3_TWITTER_CONSUMER_SECRET;
+};
+
+Conf.prototype.getPath = function(resource) {
+  return this._data.path[resource];
 };
 
 Conf.prototype.getCertificate = function(cert) {

--- a/lib/front.js
+++ b/lib/front.js
@@ -28,6 +28,7 @@ var SitePath = require('./sitepath');
 var winston = require('winston'),
     expressWinston = require('express-winston');
 var expstate = require('express-state');
+var Conf = require('./conf');
 
 expstate.extend(app);
 
@@ -59,9 +60,9 @@ app.use(methodOverride());
 app.use(session({secret: 'keyboard cat', resave: false, saveUninitialized: true}));
 app.use(flash());
 
-app.use('/resources/', serveIndex(path.join(__dirname, '../scheme/default/static')));
-app.use('/resources/', serveStatic(path.join(__dirname, '../scheme/default/static')));
-app.use(favicon('./scheme/default/static/favicon.ico'));
+app.use('/resources/', serveIndex(Conf.getPath('resources')));
+app.use('/resources/', serveStatic(Conf.getPath('resources')));
+app.use(favicon(Conf.getPath('resources') + '/favicon.ico'));
 
 if (forceAuth) {
   var forceAuthMiddleware = require('./middleware/force_auth');


### PR DESCRIPTION
observed while working with docker-compose